### PR TITLE
Fix mock trainer

### DIFF
--- a/prompt2model/trainer/base.py
+++ b/prompt2model/trainer/base.py
@@ -5,11 +5,22 @@ from typing import Any
 
 import datasets
 import transformers
+from transformers import AutoModel, AutoTokenizer
 
 
 # pylint: disable=too-few-public-methods
 class Trainer(ABC):
     """Train a model with a fixed set of hyperparameters."""
+
+    def __init__(self, pretrained_model_name: str):
+        """Initialize a model trainer.
+
+        Args:
+            pretrained_model_name: A HuggingFace model name to use for training.
+        """
+        self.model = AutoModel.from_pretrained(pretrained_model_name)
+        self.tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name)
+        self.wandb = None
 
     @abstractmethod
     def train_model(

--- a/prompt2model/trainer/mock.py
+++ b/prompt2model/trainer/mock.py
@@ -4,28 +4,13 @@ from typing import Any
 
 import datasets
 from transformers import PreTrainedModel  # noqa
-from transformers import AutoModel, AutoTokenizer, PreTrainedTokenizer
+from transformers import PreTrainedTokenizer
 
 from prompt2model.trainer import Trainer
 
 
 class MockTrainer(Trainer):
     """This dummy trainer does not actually train anything."""
-
-    def __init__(self, pretrained_model_name: str):
-        """Initialize a dummy model trainer.
-
-        Args:
-            pretrained_model_name: A HuggingFace model name to use for training.
-        """
-        self.model = AutoModel.from_pretrained(pretrained_model_name)
-        self.tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name)
-        self.wandb = None
-
-    def set_up_weights_and_biases(self) -> None:
-        """Set up Weights & Biases logging."""
-        self.wandb = None
-        raise NotImplementedError
 
     def train_model(
         self,


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

<!-- EDIT HERE:
Write a detailed description of this change,
including backgrounds, approaches, and any other information that are related to this change.
-->

Changes in our `Trainer`.

1. Add `_ = training_datasets, hyperparameter_choices` in `MockTrainer` to suppress unused variable warnings.
2. I moved the `__init__` to `base.py` since later, `SimpleTrainer` will also share this function. And I also rename `pretrained_model_id` to `pretrained_model_name`.
3. I deleted `set_up_weights_and_biases` in `MockTrainer`. Note that our `wandb` sets up in the `__init__` function. But perhaps we should clarify this in the doc string of `__init__`. 🤔


# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- NA

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
