### PR TITLE
rename `model ID` to `model name`

### DIFF
--- a/prompt2model/model_retriever/base.py
+++ b/prompt2model/model_retriever/base.py
@@ -20,5 +20,5 @@ class ModelRetriever(ABC):
             prompt: A prompt to use to select relevant models.
 
         Return:
-            A relevant model's HuggingFace ID string.
+            A relevant model's HuggingFace name.
         """

--- a/prompt2model/model_retriever/mock.py
+++ b/prompt2model/model_retriever/mock.py
@@ -7,9 +7,9 @@ from prompt2model.prompt_parser import PromptSpec
 class MockModelRetriever(ModelRetriever):
     """Select a fixed model from among a set of hyperparameter choices."""
 
-    def __init__(self, fixed_model_id: str):
-        """Initialize a dummy retriever that returns a fixed model ID."""
-        self.fixed_model_id = fixed_model_id
+    def __init__(self, fixed_model_name: str):
+        """Initialize a dummy retriever that returns a fixed model name."""
+        self.fixed_model_name = fixed_model_name
 
     def retrieve(
         self,
@@ -21,6 +21,6 @@ class MockModelRetriever(ModelRetriever):
             prompt: A prompt to use to select relevant models.
 
         Return:
-            A relevant model's HuggingFace ID string.
+            A relevant model's HuggingFace name.
         """
-        return self.fixed_model_id
+        return self.fixed_model_name

--- a/prompt2model/run_locally.py
+++ b/prompt2model/run_locally.py
@@ -79,9 +79,9 @@ def run_skeleton(prompt_tokens: list[str], metrics_output_path: str) -> None:
     all_training = retrieved_training + [generated_training]
 
     model_retriever = MockModelRetriever("cardiffnlp/twitter-roberta-base-sentiment")
-    retrieved_model_id = model_retriever.retrieve(prompt_spec)
+    retrieved_model_name = model_retriever.retrieve(prompt_spec)
 
-    trainer = MockTrainer(retrieved_model_id)
+    trainer = MockTrainer(retrieved_model_name)
     selector = MockParamSelector(trainer)
     model, tokenizer = selector.select_from_hyperparameters(
         all_training, validation, {}


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Our previous skeleton used `model ID`. A more proper way is to use `model name`.

# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- https://github.com/viswavi/prompt2model/issues/42

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
