### PR TITLE
debug tokenizer

### DIFF
--- a/prompt2model/model_trainer/generate.py
+++ b/prompt2model/model_trainer/generate.py
@@ -49,8 +49,8 @@ class GenerationModelTrainer(BaseTrainer):
             )
             if self.tokenizer.pad_token is None:
                 self.tokenizer.add_special_tokens({"pad_token": "[PAD]"})
-                if self.model.config.pad_token_id is None:
-                    self.model.config.pad_token_id = self.model.config.eos_token_id
+            if self.model.config.pad_token_id is None:
+                self.model.config.pad_token_id = self.model.config.eos_token_id
                 self.model.config.attention_mask_fn = lambda input_ids: (
                     input_ids != self.model.config.pad_token_id
                 ).float()


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

I noticed that when `gpt2` is inferencing, I get the following:

```py
Using pad_token, but it is not set yet.
The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.
Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
```

Thus I realized I hadn't set the attention mask and pad token ID. So I changed it in the `Trainer` to ensure that the model behaves as expected during open-end generation and prevents any unexpected issues related to padding and attention.

# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- NA

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
