### PR TITLE
ban wandb in unit test

### DIFF
--- a/tests/model_trainer_test.py
+++ b/tests/model_trainer_test.py
@@ -1,11 +1,14 @@
 """Testing GenerationModelTrainer with different configurations."""
 
+import os
 import tempfile
 
 import datasets
 import transformers
 
 from prompt2model.model_trainer.generate import GenerationModelTrainer
+
+os.environ["WANDB_MODE"] = "dryrun"
 
 
 def test_t5_trainer():


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Following https://github.com/viswavi/prompt2model/issues/65, I use `dryrun` to avoid `wandb` sync.
# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- NA.

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- https://github.com/viswavi/prompt2model/pull/64
