### PR TITLE
add evaluation datasets for training

### DIFF
--- a/prompt2model/model_trainer/generate.py
+++ b/prompt2model/model_trainer/generate.py
@@ -117,16 +117,15 @@ class GenerationModelTrainer(BaseTrainer):
         # Concatenate and preprocess the training datasets
         training_dataset = concatenate_datasets(training_datasets)
         shuffled_dataset = training_dataset.shuffle(seed=seed_generator.get_seed())
-        preprocessed_dataset = self.preprocess_dataset(shuffled_dataset)
-        ds_train, ds_valid = preprocessed_dataset.train_test_split(
-            test_size=0.2, seed=42
-        )
+        preprocessed_dataset = self.preprocess_dataset(
+            shuffled_dataset
+        ).train_test_split(test_size=0.2, seed=seed_generator.get_seed())
         # Create the trainer
         trainer = Trainer(
             model=self.model,
             args=self.training_args,
-            train_dataset=ds_train,
-            eval_dataset=ds_valid,
+            train_dataset=preprocessed_dataset["train"],
+            eval_dataset=preprocessed_dataset["test"],
             data_collator=transformers.DataCollatorForSeq2Seq(tokenizer=self.tokenizer)
             if self.has_encoder
             else transformers.DataCollatorForLanguageModeling(


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Our previous trainer didn’t provide an evaluation dataset. So I plan to extract 20% of training data for evaluation. Or can we set `evaluation_strategy=None`? By the way, since we are using `chrf++, exact_match, bert_score` in evaluation, should we set the same metrics for training?

# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- [ValueError: Trainer: evaluation requires an eval_dataset](https://discuss.huggingface.co/t/valueerror-trainer-evaluation-requires-an-eval-dataset/40670)
- https://github.com/viswavi/prompt2model/issues/95

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
