### PR TITLE
Add real training metric

### DIFF
--- a/prompt2model/model_trainer/generate.py
+++ b/prompt2model/model_trainer/generate.py
@@ -37,9 +37,8 @@ class GenerationModelTrainer(BaseTrainer):
             has_encoder: Whether the model has an encoder.
                 If True, it's a T5-type model (encoder-decoder transformer).
                 If fasle, it's a GPT-type model (atuoregressive transformer).
-            model_max_length: model_max_length allows model to handle
-                longer sequences, and customize sequence lengths as required
-                for your specific use case.
+            model_max_length: this sets the maximum sentence length allowed by an
+            encoder-decoder model. This can be customized for your specific use case.
         """
         self.has_encoder = has_encoder
         self.training_args = Seq2SeqTrainingArguments(
@@ -62,7 +61,9 @@ class GenerationModelTrainer(BaseTrainer):
                 )
         else:
             if model_max_length is not None:
-                logging.warning("model_max_length is only supported for T5 models")
+                logging.warning(
+                    "model_max_length is only supported for encoder-decoder models"
+                )
             self.model = transformers.AutoModelForCausalLM.from_pretrained(
                 pretrained_model_name
             )
@@ -119,7 +120,7 @@ class GenerationModelTrainer(BaseTrainer):
             hyperparameter_choices: A dictionary of hyperparameter choices.
             training_datasets: Training datasets with `input_col` and `output_col`.
             validation_datasets: Validation datasets during training. If not provided,
-                15% of training data will be splited from training_datasets to validate.
+                15% of training data will be spilt from training_datasets to validate.
 
         Returns:
             A trained HuggingFace model and tokenizer.


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Previously we have added the real evaluation dataset to evaluate during training. Here I made several small but important changes.

1. Change the save and evaluate strategy to epoch.
2.  Add `chrf`, `exact_match` and `bert_score` to evaluate during training.
3. Change `Trainer` and `Argument` to `Seq2SeqTrainer` and `Seq2SeqArgument`.

Thus we have a more powerful and detailed trainer.

# References

- https://github.com/viswavi/prompt2model/issues/107

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
