### PR TITLE
Fix eos label adding

### DIFF
--- a/prompt2model/dataset_processor/base.py
+++ b/prompt2model/dataset_processor/base.py
@@ -38,14 +38,15 @@ class BaseProcessor(ABC):
         Args:
             example: A dictionary representing an example.
             instruction: The instruction used as a prefix to explain the task.
-            task_id: A tag marking which dataset (from dataset_dicts) this example
-                comes from. Used for multi-task training.
+            task_id: A tag marking which dataset (from dataset_dicts) this
+                example comes from. Used for multi-task training.
             has_encoder: Whether the retrieved model has an encoder.
             dataset_split: The split of the example, i.e. train/val/test.
             eos_token: The end-of-sentence token of the tokenizer.
 
         Returns:
-            A dictionary with `model_input` as the input to models.
+            A dictionary with `model_input` as the input to models
+            and `model_output` as the expected output of models.
         """
 
     def process_dataset_dict(

--- a/prompt2model/dataset_processor/mock.py
+++ b/prompt2model/dataset_processor/mock.py
@@ -24,17 +24,22 @@ class MockProcessor(BaseProcessor):
         return dataset_dicts
 
     def post_process_example(example: dict, instruction: str, task_id: int) -> dict:
-        """A mock function that modifies the input column of a given example dictionary.
+        """A mock function that modifies a given example dictionary.
 
         Args:
             example: A dictionary representing an example.
             instruction: The instruction used as a prefix to explain the task.
             task_id: A tag marking which dataset (from dataset_dicts) this example
                 comes from. Used for multi-task training.
+            has_encoder: Whether the retrieved model has an encoder.
+            dataset_split: The split of the example, i.e. train/val/test.
+            eos_token: The end-of-sentence token of the tokenizer.
 
         Returns:
-            A dictionary representing the modified example.
+            A dictionary with `model_input` as the input to models
+            and `model_output` as the expected output of models.
         """
         _ = instruction, task_id
         example["model_input"] = example["input_col"]
+        example["model_output"] = example["output_col"]
         return example

--- a/prompt2model/dataset_processor/textualize.py
+++ b/prompt2model/dataset_processor/textualize.py
@@ -1,10 +1,43 @@
 """A dataset processor to convert datasets into Text2Text fashion."""
 
+from __future__ import annotations  # noqa FI58
+
+import logging
+
 from prompt2model.dataset_processor.base import BaseProcessor
 
 
 class TextualizeProcessor(BaseProcessor):
     """A class for post-processing datasets, convert them into Text2Text fashion."""
+
+    def __init__(self, has_encoder: bool, eos_token: str | None = None) -> None:
+        """Initialize the `TextualizeProcessor`.
+
+        Args:
+            has_encoder: Whether the retrieved model has an encoder.
+                Encoder-decoder model like T5 has two model inputs.
+                Decoder-only model like GPT only has one model input, thus
+                `model_input` should be added with the `output_col`.
+            eos_token: The end-of-sentence token of the tokenizer.
+                The T5 tokenizer automatically adds eos token in the end of
+                sequence. So only TextualizeProcessor for GPT model
+                requires eos_token.
+        """
+        super().__init__(has_encoder, eos_token)
+        if has_encoder and eos_token is not None:
+            logging.info(
+                (
+                    "The T5 tokenizer automatically adds eos token in the end of sequence in when tokenizing."  # noqa E501
+                    " So the eos_token of encoder-decoder model tokenizer is unnecessary."  # noqa E501
+                )
+            )
+        elif not has_encoder and eos_token is None:
+            logging.warning(
+                (
+                    "The autoregressive model tokenizer does not automatically add eos token in the end of the sequence."  # noqa E501
+                    " So the `eos_token` of the autoregressive model is required."  # noqa E501
+                )
+            )
 
     @staticmethod
     def post_process_example(
@@ -13,7 +46,7 @@ class TextualizeProcessor(BaseProcessor):
         task_id: int,
         has_encoder: bool,
         dataset_split: str,
-        eos_token: str,
+        eos_token: str | None = None,
     ) -> dict:
         """Modifies the input column of a given example dictionary.
 
@@ -27,7 +60,8 @@ class TextualizeProcessor(BaseProcessor):
             eos_token: The end-of-sentence token of the tokenizer.
 
         Returns:
-            A dictionary with `model_input` as the input to models.
+            A dictionary with `model_input` as the input to models
+            and `model_output` as the expected output of models.
         """
         assert (
             "input_col" in example and "output_col" in example
@@ -37,22 +71,19 @@ class TextualizeProcessor(BaseProcessor):
             "val",
             "test",
         ), "Split must be one of train/val/test"
+
         if has_encoder:
-            model_input = (
-                f"<task {task_id}> {instruction} Example: {example['input_col']}"
-                + " Label: "
-            )
-            example["output_col"] += eos_token
+            model_input = f"<task {task_id}>{instruction}\nExample:\n{example['input_col']}\nLabel:\n"  # noqa E501
+            model_output = example["output_col"]
         else:
+            # The T5 tokenizer automatically adds eos token in `add eos if not present`.
+            # So the model_output for T5 model should not have eos token in the end.
+            # On the contrary, model_output of GPT model need eos token in the end.
+            model_output = example["output_col"] + eos_token
             if dataset_split == "train":
-                model_input = (
-                    f"<task {task_id}> {instruction} Example: {example['input_col']}"
-                    + f" Label: {example['output_col']}{eos_token}"
-                )
+                model_input = f"<task {task_id}>{instruction}\nExample:\n{example['input_col']}\nLabel:\n{model_output}"  # noqa E501
             else:
-                model_input = (
-                    f"<task {task_id}> {instruction} Example: {example['input_col']}"
-                    + " Label: "
-                )
+                model_input = f"<task {task_id}>{instruction}\nExample:\n{example['input_col']}\nLabel:\n"  # noqa E501
         example["model_input"] = model_input
+        example["model_output"] = model_output
         return example

--- a/tests/dataset_processor_test.py
+++ b/tests/dataset_processor_test.py
@@ -1,5 +1,7 @@
 """Testing TextualizeProcessor."""
 
+from unittest.mock import patch
+
 import datasets
 import pytest
 from transformers import T5Tokenizer
@@ -11,24 +13,39 @@ DATASET_DICTS = [
     datasets.DatasetDict(
         {
             "train": datasets.Dataset.from_dict(
-                {"input_col": ["foo", "bar"], "output_col": ["baz", "qux"]}
+                {
+                    "input_col": ["foo", "bar"],
+                    "output_col": ["baz", "qux"],
+                }
             ),
             "test": datasets.Dataset.from_dict(
-                {"input_col": ["foo", "bar"], "output_col": ["baz", "qux"]}
+                {
+                    "input_col": ["foo", "bar"],
+                    "output_col": ["baz", "qux"],
+                }
             ),
         }
     ),
     datasets.DatasetDict(
         {
             "train": datasets.Dataset.from_dict(
-                {"input_col": ["spam", "eggs"], "output_col": ["ham", "sau"]}
+                {
+                    "input_col": ["spam", "eggs"],
+                    "output_col": ["ham", "sau"],
+                }
             ),
             "val": datasets.Dataset.from_dict(
-                {"input_col": ["spam", "eggs"], "output_col": ["ham", "sau"]}
+                {
+                    "input_col": ["spam", "eggs"],
+                    "output_col": ["ham", "sau"],
+                }
             ),
         }
     ),
 ]
+
+
+INSTRUCTION = "convert to text2text"
 
 # Our support spilts are `train, val, test`.
 UNEXPECTED_DATASET_DICTS_WITH_WRONG_SPLIT = [
@@ -66,7 +83,27 @@ UNEXPECTED_DATASET_DICTS_WITH_WRONG_COLUMNS = [
     ),
 ]
 
-INSTRUCTION = "convert to text2text"
+
+def test_the_logging_for_provide_unnecessary_eos_token_for_t5():
+    """Test the logging.info for unnecessary eos token for T5 model is logged."""
+    t5_tokenizer = T5Tokenizer.from_pretrained("t5-small")
+
+    with patch("logging.info") as mock_info, patch("logging.warning") as mock_warning:
+        _ = TextualizeProcessor(has_encoder=True, eos_token=t5_tokenizer.eos_token)
+        mock_info.assert_called_once_with(
+            "The T5 tokenizer automatically adds eos token in the end of sequence in when tokenizing. So the eos_token of encoder-decoder model tokenizer is unnecessary."  # noqa E501
+        )
+        mock_warning.assert_not_called()
+
+
+def test_the_logging_for_eos_token_required_for_gpt():
+    """Test the logging.warning for requiring eos token for GPT model is logged."""
+    with patch("logging.info") as mock_info, patch("logging.warning") as mock_warning:
+        _ = TextualizeProcessor(has_encoder=False)
+        mock_info.assert_not_called()
+        mock_warning.assert_called_once_with(
+            "The autoregressive model tokenizer does not automatically add eos token in the end of the sequence. So the `eos_token` of the autoregressive model is required."  # noqa E501
+        )
 
 
 def test_dataset_processor_t5_style():
@@ -84,21 +121,23 @@ def test_dataset_processor_t5_style():
                 "train": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 0> convert to text2text Example: foo Label: ",
-                            "<task 0> convert to text2text Example: bar Label: ",
+                            "<task 0>convert to text2text\nExample:\nfoo\nLabel:\n",
+                            "<task 0>convert to text2text\nExample:\nbar\nLabel:\n",
                         ],
-                        "input_col": ["spam", "eggs"],
-                        "output_col": ["baz</s>", "qux</s>"],
+                        "input_col": ["foo", "bar"],
+                        "output_col": ["baz", "qux"],
+                        "model_output": ["baz", "qux"],
                     }
                 ),
                 "test": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 0> convert to text2text Example: foo Label: ",
-                            "<task 0> convert to text2text Example: bar Label: ",
+                            "<task 0>convert to text2text\nExample:\nfoo\nLabel:\n",
+                            "<task 0>convert to text2text\nExample:\nbar\nLabel:\n",
                         ],
-                        "input_col": ["spam", "eggs"],
-                        "output_col": ["baz</s>", "qux</s>"],
+                        "input_col": ["foo", "bar"],
+                        "output_col": ["baz", "qux"],
+                        "model_output": ["baz", "qux"],
                     }
                 ),
             }
@@ -108,21 +147,23 @@ def test_dataset_processor_t5_style():
                 "train": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 1> convert to text2text Example: spam Label: ",
-                            "<task 1> convert to text2text Example: eggs Label: ",
+                            "<task 1>convert to text2text\nExample:\nspam\nLabel:\n",
+                            "<task 1>convert to text2text\nExample:\neggs\nLabel:\n",
                         ],
                         "input_col": ["spam", "eggs"],
-                        "output_col": ["ham</s>", "sau</s>"],
+                        "output_col": ["ham", "sau"],
+                        "model_output": ["ham", "sau"],
                     }
                 ),
                 "val": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 1> convert to text2text Example: spam Label: ",
-                            "<task 1> convert to text2text Example: eggs Label: ",
+                            "<task 1>convert to text2text\nExample:\nspam\nLabel:\n",
+                            "<task 1>convert to text2text\nExample:\neggs\nLabel:\n",
                         ],
                         "input_col": ["spam", "eggs"],
-                        "output_col": ["ham</s>", "sau</s>"],
+                        "output_col": ["ham", "sau"],
+                        "model_output": ["ham", "sau"],
                     }
                 ),
             }
@@ -133,8 +174,20 @@ def test_dataset_processor_t5_style():
         dataset_splits = list(dataset_dict.keys())
         for dataset_split in dataset_splits:
             assert (
+                dataset_dict[dataset_split]["input_col"]
+                == t5_expected_dataset_dicts[index][dataset_split]["input_col"]
+            )
+            assert (
                 dataset_dict[dataset_split]["model_input"]
                 == t5_expected_dataset_dicts[index][dataset_split]["model_input"]
+            )
+            assert (
+                dataset_dict[dataset_split]["output_col"]
+                == t5_expected_dataset_dicts[index][dataset_split]["output_col"]
+            )
+            assert (
+                dataset_dict[dataset_split]["model_output"]
+                == t5_expected_dataset_dicts[index][dataset_split]["model_output"]
             )
 
 
@@ -155,21 +208,23 @@ def test_dataset_processor_decoder_only_style():
                 "train": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 0> convert to text2text Example: foo Label: baz<|endoftext|>",  # noqa: E501
-                            "<task 0> convert to text2text Example: bar Label: qux<|endoftext|>",  # noqa: E501
+                            "<task 0>convert to text2text\nExample:\nfoo\nLabel:\nbaz<|endoftext|>",  # noqa: E501
+                            "<task 0>convert to text2text\nExample:\nbar\nLabel:\nqux<|endoftext|>",  # noqa: E501
                         ],
-                        "input_col": ["spam", "eggs"],
+                        "input_col": ["foo", "bar"],
                         "output_col": ["baz", "qux"],
+                        "model_output": ["baz<|endoftext|>", "qux<|endoftext|>"],
                     }
                 ),
                 "test": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 0> convert to text2text Example: foo Label: ",
-                            "<task 0> convert to text2text Example: bar Label: ",
+                            "<task 0>convert to text2text\nExample:\nfoo\nLabel:\n",
+                            "<task 0>convert to text2text\nExample:\nbar\nLabel:\n",
                         ],
-                        "input_col": ["spam", "eggs"],
+                        "input_col": ["foo", "bar"],
                         "output_col": ["baz", "qux"],
+                        "model_output": ["baz<|endoftext|>", "qux<|endoftext|>"],
                     }
                 ),
             }
@@ -179,21 +234,23 @@ def test_dataset_processor_decoder_only_style():
                 "train": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 1> convert to text2text Example: spam Label: ham<|endoftext|>",  # noqa: E501
-                            "<task 1> convert to text2text Example: eggs Label: sau<|endoftext|>",  # noqa: E501
+                            "<task 1>convert to text2text\nExample:\nspam\nLabel:\nham<|endoftext|>",  # noqa: E501
+                            "<task 1>convert to text2text\nExample:\neggs\nLabel:\nsau<|endoftext|>",  # noqa: E501
                         ],
                         "input_col": ["spam", "eggs"],
                         "output_col": ["ham", "sau"],
+                        "model_output": ["ham<|endoftext|>", "sau<|endoftext|>"],
                     }
                 ),
                 "val": datasets.Dataset.from_dict(
                     {
                         "model_input": [
-                            "<task 1> convert to text2text Example: spam Label: ",
-                            "<task 1> convert to text2text Example: eggs Label: ",
+                            "<task 1>convert to text2text\nExample:\nspam\nLabel:\n",
+                            "<task 1>convert to text2text\nExample:\neggs\nLabel:\n",
                         ],
                         "input_col": ["spam", "eggs"],
                         "output_col": ["ham", "sau"],
+                        "model_output": ["ham<|endoftext|>", "sau<|endoftext|>"],
                     }
                 ),
             }
@@ -204,8 +261,20 @@ def test_dataset_processor_decoder_only_style():
         dataset_splits = list(dataset_dict.keys())
         for dataset_split in dataset_splits:
             assert (
+                dataset_dict[dataset_split]["input_col"]
+                == gpt_expected_dataset_dicts[index][dataset_split]["input_col"]
+            )
+            assert (
                 dataset_dict[dataset_split]["model_input"]
                 == gpt_expected_dataset_dicts[index][dataset_split]["model_input"]
+            )
+            assert (
+                dataset_dict[dataset_split]["output_col"]
+                == gpt_expected_dataset_dicts[index][dataset_split]["output_col"]
+            )
+            assert (
+                dataset_dict[dataset_split]["model_output"]
+                == gpt_expected_dataset_dicts[index][dataset_split]["model_output"]
             )
 
 


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

This PR is decoupled. Basically, it differentiates the T5 model and decoder-only models in how to add the `eos` token at the end of `model_input` and create a new column called `model_output` to be consistent with `model_input`.

# References

<!-- EDIT HERE: Put the list of issues, discussions related to this change. -->

- NA

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- (or link to PRs)
