### PR TITLE
Simplify calls in prompt_parser tests

### DIFF
--- a/test_helpers/__init__.py
+++ b/test_helpers/__init__.py
@@ -6,7 +6,6 @@ from test_helpers.dataset_tools import (
 from test_helpers.mock_openai import (
     MockBatchResponseDifferentCompletions,
     MockCompletion,
-    MockOneOpenAIResponse,
     mock_batch_openai_response_identical_completions,
 )
 from test_helpers.model_and_tokenizer import (

--- a/test_helpers/mock_openai.py
+++ b/test_helpers/mock_openai.py
@@ -36,22 +36,6 @@ class MockCompletion:
         return _string
 
 
-class MockOneOpenAIResponse:
-    """Mock one response with a single completion."""
-
-    def __init__(
-        self,
-        prompt: str = "",
-        temperature: float = 1,
-        presence_penalty: float = 0,
-        frequency_penalty: float = 0,
-        content: str = "",
-    ) -> None:
-        """Init a new instance of `MockOneOpenAIResponse`."""
-        _ = prompt, temperature, presence_penalty, frequency_penalty
-        self.mock_completion = MockCompletion(content=content)
-
-
 def mock_batch_openai_response_identical_completions(
     prompts: list[str],
     content: str,

--- a/tests/prompt_parser_test.py
+++ b/tests/prompt_parser_test.py
@@ -1,4 +1,4 @@
-"""Testing integration of components locally."""
+"""Tests for the prompt_parser module."""
 
 import gc
 import os
@@ -8,14 +8,14 @@ import openai
 import pytest
 
 from prompt2model.prompt_parser import OpenAIInstructionParser, TaskType
-from test_helpers import MockOneOpenAIResponse
+from test_helpers.mock_openai import MockCompletion
 
-GPT3_RESPONSE_WITH_DEMONSTRATIONS = (
+GPT3_RESPONSE_WITH_DEMONSTRATIONS = MockCompletion(
     '{"Instruction": "Convert each date from an informal description into a'
     ' MM/DD/YYYY format.", "Demonstrations": "Fifth of November 2024 ->'
     ' 11/05/2024\nJan. 9 2023 -> 01/09/2023\nChristmas 2016 -> 12/25/2016"}'
 )
-GPT3_RESPONSE_WITHOUT_DEMONSTRATIONS = (
+GPT3_RESPONSE_WITHOUT_DEMONSTRATIONS = MockCompletion(
     '{"Instruction": "Turn the given fact into a question by a simple rearrangement'
     " of words. This typically involves replacing some part of the given fact with a"
     " WH word. For example, replacing the subject of the provided fact with the word"
@@ -27,7 +27,7 @@ GPT3_RESPONSE_WITHOUT_DEMONSTRATIONS = (
     " You can also form a question without any WH words. For example, 'A radio"
     ' converts electricity into?\'", "Demonstrations": "N/A"}'
 )
-GPT3_RESPONSE_WITH_INVALID_JSON = (
+GPT3_RESPONSE_WITH_INVALID_JSON = MockCompletion(
     '{"Instruction": "A", "Demonstrations": "B}'  # Missing final quotation mark
 )
 
@@ -40,9 +40,7 @@ class UNKNOWN_GPT3_EXCEPTION(Exception):
 
 @patch(
     "prompt2model.utils.ChatGPTAgent.generate_one_openai_chat_completion",
-    side_effect=[
-        MockOneOpenAIResponse(content=GPT3_RESPONSE_WITH_DEMONSTRATIONS).mock_completion
-    ],
+    side_effect=[GPT3_RESPONSE_WITH_DEMONSTRATIONS],
 )
 def test_instruction_parser_with_demonstration(mocked_parsing_method):
     """Test a prompt-based instruction (with the LLM call mocked).
@@ -81,11 +79,7 @@ Christmas 2016 -> 12/25/2016"""
 
 @patch(
     "prompt2model.utils.ChatGPTAgent.generate_one_openai_chat_completion",
-    side_effect=[
-        MockOneOpenAIResponse(
-            content=GPT3_RESPONSE_WITHOUT_DEMONSTRATIONS
-        ).mock_completion
-    ],
+    side_effect=[GPT3_RESPONSE_WITHOUT_DEMONSTRATIONS],
 )
 def test_instruction_parser_without_demonstration(mocked_parsing_method):
     """Test a prompt-based instruction (with the LLM call mocked).
@@ -112,10 +106,7 @@ def test_instruction_parser_without_demonstration(mocked_parsing_method):
 
 @patch(
     "prompt2model.utils.ChatGPTAgent.generate_one_openai_chat_completion",
-    side_effect=[
-        MockOneOpenAIResponse(content=GPT3_RESPONSE_WITH_INVALID_JSON).mock_completion
-    ]
-    * 3,
+    side_effect=[GPT3_RESPONSE_WITH_INVALID_JSON] * 3,
 )
 def test_instruction_parser_with_invalid_json(mocked_parsing_method):
     """Verify that we handle when the API returns a invalid JSON response.


### PR DESCRIPTION
# Description

This PR simplifies the mocking of OpenAI responses by removing `MockOneOpenAIResponse` and just returning `MockCompletion` directly from `side_effect`.

# Blocked by

- NA

