### PR TITLE
Suppress spurious markdown lint errors in README

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+MD013:
+  line_length: 120
+  code_blocks: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
 MD013:
   line_length: 120
   code_blocks: false
+MD033: false

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For example, `input=""` is better than breaking
 the line after `=`.
 3. Use `input` rather than `Input`, `ouput` is
 preferable likewise.
-4. Warp the `input` and `output` into a string with `“”`.
+4. Wrap the `input` and `output` into a string with `“”`.
 
 Though the examples are optional, we strongly
 suggest including them to guide the format and

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ language task description (like the ones used for
 LLMs such as ChatGPT) to train a small
 special-purpose model that is conducive for deployment.
 
-<img width="360" alt="prompt2model_teaser" src="https://github.com/neulab/prompt2model/assets/2577384/7acc8ce4-4909-426f-a759-542a324d38d0">
+<img width="360" alt="prompt2model_teaser" src="https://github.com/neulab/prompt2model/assets/2577384/39ca466a-5355-4d82-8312-303e52ba2bca">
 
 ## Quick Start
 ```bash
@@ -42,7 +42,9 @@ this script on a device with a GPU for training
 your model.
 
 ## Demo
-https://github.com/neulab/prompt2model/assets/2577384/a8781119-f518-4dbd-b497-cf1ee4a078a9
+https://github.com/neulab/prompt2model/assets/2577384/8f0a31d0-ded1-4c81-841b-0fee41153256
+
+
 
 ## How to Write a Good Prompt
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ this script on a device with a GPU for training
 your model.
 
 ## Demo
-https://github.com/neulab/prompt2model/assets/2577384/8f0a31d0-ded1-4c81-841b-0fee41153256
+https://github.com/neulab/prompt2model/assets/2577384/8d73394b-3028-4a0b-bdc3-c127082868f2
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ language task description (like the ones used for
 LLMs such as ChatGPT) to train a small
 special-purpose model that is conducive for deployment.
 
-<img width="360" alt="prompt2model_teaser" src="https://github.com/neulab/prompt2model/assets/2577384/39ca466a-5355-4d82-8312-303e52ba2bca">  {{< mdl-disable "<!-- markdownlint-disable MD033 -->" >}} {{< mdl-disable "<!-- markdownlint-disable MD013 -->" >}}
+<img width="360" alt="prompt2model_teaser" src="https://github.com/neulab/prompt2model/assets/2577384/39ca466a-5355-4d82-8312-303e52ba2bca">
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ special-purpose model that is conducive for deployment.
 <img width="360" alt="prompt2model_teaser" src="https://github.com/neulab/prompt2model/assets/2577384/39ca466a-5355-4d82-8312-303e52ba2bca">
 
 ## Quick Start
+
 ```bash
 pip install .
 ```
@@ -30,11 +31,13 @@ export OPENAI_API_KEY=<your key>
 ```
 
 You can then run
-```
+
+```bash
 python cli_demo.py
 ```
-to 
-create a small model from a prompt, as shown in 
+
+to
+create a small model from a prompt, as shown in
 the demo video below. This script must be run on a
 device with an internet connection to access the OpenAI
 API. For best results, run
@@ -42,10 +45,8 @@ this script on a device with a GPU for training
 your model.
 
 ## Demo
-https://github.com/neulab/prompt2model/assets/2577384/8d73394b-3028-4a0b-bdc3-c127082868f2
 
-
-
+<https://github.com/neulab/prompt2model/assets/2577384/8d73394b-3028-4a0b-bdc3-c127082868f2>
 
 ## How to Write a Good Prompt
 
@@ -82,7 +83,6 @@ Also, we recommend providing several precise examples
 in the specified format and inquiring with ChatGPT
 about the format and scope of your examples.
 
-
 ## Components
 
 The `prompt2model` package is composed
@@ -107,16 +107,16 @@ refer to [CONTRIBUTING.md](CONTRIBUTING.md),
 or reach out to [@vijaytarian](https://twitter.com/vijaytarian)
 and [@ChenytangZhao](https://twitter.com/ChenytangZhao).
 
-
 ## Cite
 
 We have [written a paper describing Prompt2Model in detail](https://arxiv.org/abs/YYMM.XXXXX).
 
 If you use Prompt2Model in your research, please cite our paper:
-```
+
+```bibtex
 @misc{prompt2model,
-      title={Prompt2Model: Generating Deployable Models from Natural Language Instructions}, 
-      author={Vijay Viswanathan and Chenyang Zhao and Amanda Bertsch and Tongshuang Wu and Graham Neubig},
+      title={Prompt2Model: Generating Deployable Models from Natural Language Instructions}, {{< mdl-disable "<!-- markdownlint-disable MD013 -->" >}}
+      author={Vijay Viswanathan and Chenyang Zhao and Amanda Bertsch and Tongshuang Wu and Graham Neubig}, {{< mdl-disable "<!-- markdownlint-disable MD013 -->" >}}
       year={2023},
       eprint={YYMM.XXXXX},
       archivePrefix={arXiv},

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ language task description (like the ones used for
 LLMs such as ChatGPT) to train a small
 special-purpose model that is conducive for deployment.
 
-<img width="360" alt="prompt2model_teaser" src="https://github.com/neulab/prompt2model/assets/2577384/39ca466a-5355-4d82-8312-303e52ba2bca">
+<img width="360" alt="prompt2model_teaser" src="https://github.com/neulab/prompt2model/assets/2577384/39ca466a-5355-4d82-8312-303e52ba2bca">  {{< mdl-disable "<!-- markdownlint-disable MD033 -->" >}} {{< mdl-disable "<!-- markdownlint-disable MD013 -->" >}}
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ If you use Prompt2Model in your research, please cite our paper:
 
 ```bibtex
 @misc{prompt2model,
-      title={Prompt2Model: Generating Deployable Models from Natural Language Instructions}, {{< mdl-disable "<!-- markdownlint-disable MD013 -->" >}}
-      author={Vijay Viswanathan and Chenyang Zhao and Amanda Bertsch and Tongshuang Wu and Graham Neubig}, {{< mdl-disable "<!-- markdownlint-disable MD013 -->" >}}
+      title={Prompt2Model: Generating Deployable Models from Natural Language Instructions},
+      author={Vijay Viswanathan and Chenyang Zhao and Amanda Bertsch and Tongshuang Wu and Graham Neubig},
       year={2023},
       eprint={YYMM.XXXXX},
       archivePrefix={arXiv},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "retriv==0.2.1",
     "tiktoken==0.4.0",
     "aiolimiter==1.1.0",
+    "pyfiglet==0.8.post1",
+    "termcolor==2.3.0",
+    "psutil==5.9.5",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

`markdownlint-cli2` was complaining about certain errors in our README that are not actually a concern. This PR suppresses those errors on a line-by-line basis.

# References

N/A

# Blocked by

N/A