### PR TITLE
Add the mock parameter selector back in

### DIFF
--- a/prompt2model/param_selector/__init__.py
+++ b/prompt2model/param_selector/__init__.py
@@ -1,0 +1,5 @@
+"""Import model selector classes."""
+from prompt2model.param_selector.base import ParamSelector
+from prompt2model.param_selector.mock import MockParamSelector
+
+__all__ = ("MockParamSelector", "ParamSelector")

--- a/prompt2model/param_selector/base.py
+++ b/prompt2model/param_selector/base.py
@@ -23,10 +23,12 @@ class ParamSelector(ABC):
         hyperparameters: dict[str, list[Any]],
     ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
         """Select a model among a set of hyperparameters (given or inferred).
+
         Args:
             training_sets: One or more training datasets for the trainer.
             validation: A dataset for computing validation metrics.
             hyperparameters: A dictionary of hyperparameter choices.
+
         Return:
             A model and tokenizer (with hyperparameters from given range).
         """
@@ -39,10 +41,12 @@ class ParamSelector(ABC):
         prompt_spec: PromptSpec,
     ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
         """Select a model among a set of hyperparameters (given or inferred).
+
         Args:
             training_sets: One or more training datasets for the trainer.
             validation: A dataset for computing validation metrics.
             prompt_spec: A prompt to infer hyperparameters from.
+
         Return:
             A model and tokenizer (with hyperparameters from inferred range).
         """

--- a/prompt2model/param_selector/base.py
+++ b/prompt2model/param_selector/base.py
@@ -1,0 +1,48 @@
+"""An interface for model selection."""
+
+from __future__ import annotations  # noqa FI58
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import datasets
+import transformers
+
+from prompt2model.prompt_parser.base import PromptSpec
+
+
+# pylint: disable=too-few-public-methods
+class ParamSelector(ABC):
+    """Select a good model from among a set of hyperparameter choices."""
+
+    @abstractmethod
+    def select_from_hyperparameters(
+        self,
+        training_sets: list[datasets.Dataset],
+        validation: datasets.Dataset,
+        hyperparameters: dict[str, list[Any]],
+    ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
+        """Select a model among a set of hyperparameters (given or inferred).
+        Args:
+            training_sets: One or more training datasets for the trainer.
+            validation: A dataset for computing validation metrics.
+            hyperparameters: A dictionary of hyperparameter choices.
+        Return:
+            A model and tokenizer (with hyperparameters from given range).
+        """
+
+    @abstractmethod
+    def select_from_spec(
+        self,
+        training_sets: list[datasets.Dataset],
+        validation: datasets.Dataset,
+        prompt_spec: PromptSpec,
+    ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
+        """Select a model among a set of hyperparameters (given or inferred).
+        Args:
+            training_sets: One or more training datasets for the trainer.
+            validation: A dataset for computing validation metrics.
+            prompt_spec: A prompt to infer hyperparameters from.
+        Return:
+            A model and tokenizer (with hyperparameters from inferred range).
+        """

--- a/prompt2model/param_selector/mock.py
+++ b/prompt2model/param_selector/mock.py
@@ -15,6 +15,7 @@ class MockParamSelector(ParamSelector):
 
     def __init__(self, trainer: BaseTrainer):
         """Initialize with train/val datasets and a prompt specification.
+
         Args:
             trainer: A trainer to use for training models during model selection.
         """
@@ -34,11 +35,13 @@ class MockParamSelector(ParamSelector):
         hyperparameters: dict[str, list[Any]],
     ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
         """Use a pre-defined default set of hyperparameters.
+
         Args:
             training_sets: One or more training datasets for the trainer.
             validation: A dataset for computing validation metrics.
             prompt_spec: (Optional) A prompt to infer hyperparameters from.
             hyperparameters: (Optional) A dictionary of hyperparameter choices.
+
         Return:
             A model and tokenizer (trained using default hyperparameters).
         """
@@ -54,6 +57,7 @@ class MockParamSelector(ParamSelector):
         prompt_spec: PromptSpec,
     ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
         """The MockParamSelector cannot infer hyperparameters from the spec.
+
         Args:
             training_sets: One or more training datasets for the trainer.
             validation: A dataset for computing validation metrics.

--- a/prompt2model/param_selector/mock.py
+++ b/prompt2model/param_selector/mock.py
@@ -1,0 +1,63 @@
+"""Mock model selector for testing purposes."""
+
+from typing import Any
+
+import datasets
+import transformers
+
+from prompt2model.model_trainer import BaseTrainer
+from prompt2model.param_selector.base import ParamSelector
+from prompt2model.prompt_parser import PromptSpec
+
+
+class MockParamSelector(ParamSelector):
+    """Uses a default set of parameters."""
+
+    def __init__(self, trainer: BaseTrainer):
+        """Initialize with train/val datasets and a prompt specification.
+        Args:
+            trainer: A trainer to use for training models during model selection.
+        """
+        self.trainer = trainer
+
+    def _example_hyperparameter_choices(self) -> dict[str, Any]:
+        """Example hyperparameters (for testing only)."""
+        return {
+            "optimizer": "AdamW",
+            "learning_rate": 1e-4,
+        }
+
+    def select_from_hyperparameters(
+        self,
+        training_sets: list[datasets.Dataset],
+        validation: datasets.Dataset,
+        hyperparameters: dict[str, list[Any]],
+    ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
+        """Use a pre-defined default set of hyperparameters.
+        Args:
+            training_sets: One or more training datasets for the trainer.
+            validation: A dataset for computing validation metrics.
+            prompt_spec: (Optional) A prompt to infer hyperparameters from.
+            hyperparameters: (Optional) A dictionary of hyperparameter choices.
+        Return:
+            A model and tokenizer (trained using default hyperparameters).
+        """
+        single_model = self.trainer.train_model(
+            training_sets, self._example_hyperparameter_choices()
+        )
+        return single_model
+
+    def select_from_spec(
+        self,
+        training_sets: list[datasets.Dataset],
+        validation: datasets.Dataset,
+        prompt_spec: PromptSpec,
+    ) -> tuple[transformers.PreTrainedModel, transformers.PreTrainedTokenizer]:
+        """The MockParamSelector cannot infer hyperparameters from the spec.
+        Args:
+            training_sets: One or more training datasets for the trainer.
+            validation: A dataset for computing validation metrics.
+            prompt_spec: (Optional) A prompt to infer hyperparameters from.
+            hyperparameters: (Optional) A dictionary of hyperparameter choices.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

#221 removed the mock parameter selector we had, which was an accident. We should keep this module in our skeleton for when we're ready to implement it.

This PR restores that module to the code.

# References

N/A

# Blocked by

N/A