### PR TITLE
Fix code block line length in markdownlint

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+---
+MD013:
+  line_length: 120
+  code_blocks: false


### PR DESCRIPTION
# Description

This is another attempt to fix markdownlint errors in code blocks.

# References

- Might be an alternative to #254 
