### PR TITLE
Cache dependencies for (hopefully) faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          python-version-file: 'pyproject.toml'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          python-version-file: 'pyproject.toml'
+          cache-dependency-path: 'pyproject.toml'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
# Description

Currently running unit tests takes a very long time, much of which is due to downloading dependencies. This PR attempts to fix this issue by adding a cache.

# References

- [Dependency caching for github CI](https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/)

# Blocked by

- NA
