### PR TITLE
Add top-level init file

### DIFF
--- a/prompt2model/__init__.py
+++ b/prompt2model/__init__.py
@@ -1,0 +1,1 @@
+"""prompt2model top level package."""


### PR DESCRIPTION
# Description

Previously our release workflow was broken. This was because there was no `__init__.py` file in the top-level directory where `version.py` lived, so `version.py` was not copied to the release tarball. This PR fixes this issue.

# References

- Fixes https://github.com/neulab/prompt2model/issues

# Blocked by

- NA
