### PR TITLE
Downgrade protobuf to 3.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyfiglet==0.8.post1",
     "termcolor==2.3.0",
     "psutil==5.9.5",
-    "protobuf==4.24.1",
+    "protobuf==3.20.0",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Protobuf 4.24.1 (currently set) may cause problems in many environments with our pipeline.

# References

N/A

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

N/A
