### PR TITLE
Refactor dataset retriever to isolate CLI functions

### DIFF
--- a/prompt2model/dataset_retriever/__init__.py
+++ b/prompt2model/dataset_retriever/__init__.py
@@ -1,6 +1,6 @@
 """Import DatasetRetriever classes."""
 from prompt2model.dataset_retriever.base import DatasetRetriever
-from prompt2model.dataset_retriever.hf_dataset_retriever import (
+from prompt2model.dataset_retriever.description_dataset_retriever import (
     DatasetInfo,
     DescriptionDatasetRetriever,
 )

--- a/prompt2model/dataset_retriever/base.py
+++ b/prompt2model/dataset_retriever/base.py
@@ -3,10 +3,26 @@
 from __future__ import annotations  # noqa FI58
 
 from abc import ABC, abstractmethod
+import dataclasses
 
 import datasets
 
 from prompt2model.prompt_parser import PromptSpec
+
+
+@dataclasses.dataclass
+class DatasetInfo:
+    """Store the dataset name, description, and query-dataset score for each dataset.
+
+    Args:
+        name: The name of the dataset.
+        description: The description of the dataset.
+        score: The retrieval score of the dataset.
+    """
+
+    name: str
+    description: str
+    score: float | None = None
 
 
 # pylint: disable=too-few-public-methods

--- a/prompt2model/dataset_retriever/base.py
+++ b/prompt2model/dataset_retriever/base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations  # noqa FI58
 
-from abc import ABC, abstractmethod
 import dataclasses
+from abc import ABC, abstractmethod
 
 import datasets
 
@@ -22,7 +22,7 @@ class DatasetInfo:
 
     name: str
     description: str
-    score: float | None = None
+    score: float
 
 
 # pylint: disable=too-few-public-methods

--- a/prompt2model/dataset_retriever/description_dataset_retriever.py
+++ b/prompt2model/dataset_retriever/description_dataset_retriever.py
@@ -243,6 +243,14 @@ class DescriptionDatasetRetriever(DatasetRetriever):
         self,
         prompt_spec: PromptSpec,
     ) -> list[DatasetInfo]:
+        """Retrieve the top datasets for a prompt.
+
+        Args:
+            prompt_spec: A prompt whose instruction field we use to retrieve datasets.
+
+        Returns:
+            A list of the top datasets for the prompt.
+        """
         query_vector = encode_text(
             self.encoder_model_name,
             text_to_encode=prompt_spec.instruction,

--- a/prompt2model/dataset_retriever/description_dataset_retriever.py
+++ b/prompt2model/dataset_retriever/description_dataset_retriever.py
@@ -245,11 +245,14 @@ class DescriptionDatasetRetriever(DatasetRetriever):
     ) -> list[DatasetInfo]:
         """Retrieve the top datasets for a prompt.
 
+        Specifically, the datasets are scored using a dual-encoder retriever model
+        and the datasets with the highest similarity scores with the query are returned.
+
         Args:
             prompt_spec: A prompt whose instruction field we use to retrieve datasets.
 
         Returns:
-            A list of the top datasets for the prompt.
+            A list of the top datasets for the prompt according to retriever score.
         """
         query_vector = encode_text(
             self.encoder_model_name,


### PR DESCRIPTION
# Description

In preparation for preparing our notebook demo (https://github.com/neulab/prompt2model/issues/289), it would be nice to split off the functions that require the CLI so we can replace them with more notebook-native ways of doing things. This PR starts by doing some refactoring to make the interface to the retriever a bit more cleanly separated.

# References

- Fixes: https://github.com/neulab/prompt2model/issues/292

# Blocked by

- NA
