### PR TITLE
Fix some wording and asyncio

### DIFF
--- a/notebook_demo.ipynb
+++ b/notebook_demo.ipynb
@@ -43,22 +43,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set your OpenAI API key as an environment variable. A good way to do this is to create a `.env` file with a single line:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!echo \"OPENAI_API_KEY=<your key here>\" >> .env"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "Set your OpenAI API key as an environment variable. A good way to do this is to create a `.env` file with a single line.\n",
+    "\n",
+    "```text\n",
+    "OPENAI_API_KEY=<your key here>\n",
+    "```\n",
+    "\n",
     "And then run the following command to load environment variables from your `.env` file into the running script."
    ]
   },
@@ -151,6 +141,35 @@
     "prompt_spec.parse_from_prompt(prompt)\n",
     "print(f\"Instruction:\\n{prompt_spec.instruction}\\n\")\n",
     "print(f\"Examples:\\n{prompt_spec.examples}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve Model\n",
+    "\n",
+    "First, we retrieve a base model that we will train. We can use the `DescriptionModelRetriever` to do so.\n",
+    "\n",
+    "`top_model_names` is a list of pretrained Hugging Face models. You can choose the first one by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from prompt2model.model_retriever import DescriptionModelRetriever\n",
+    "\n",
+    "retriever = DescriptionModelRetriever(\n",
+    "    model_descriptions_index_path=\"huggingface_data/huggingface_models/model_info/\",\n",
+    "    use_bm25=True,\n",
+    "    use_HyDE=True,\n",
+    ")\n",
+    "top_model_names = retriever.retrieve(prompt_spec)\n",
+    "pre_train_model_name = top_model_names[0]\n",
+    "print(pre_train_model_name)"
    ]
   },
   {
@@ -331,58 +350,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Retrieve Model\n",
-    "\n",
-    "Use the `DescriptionModelRetriever` to retrieve a pretrain model.\n",
-    "\n",
-    "The `top_model_names` is a list of pretrain model names of HuggingFace model. In our demo, we choose the first one as default."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from prompt2model.model_retriever import DescriptionModelRetriever\n",
-    "\n",
-    "retriever = DescriptionModelRetriever(\n",
-    "    model_descriptions_index_path=\"huggingface_data/huggingface_models/model_info/\",  # noqa E501\n",
-    "    use_bm25=True,\n",
-    "    use_HyDE=True,\n",
-    ")\n",
-    "top_model_names = retriever.retrieve(prompt_spec)\n",
-    "pre_train_model_name = top_model_names[0]\n",
-    "print(pre_train_model_name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Generate Dataset\n",
     "\n",
-    "Use `OpenAIDatasetGenerator` to generte new examples for the machine reading quesiton-answering task.\n",
+    "Next, we generate some examples for training the model. We can use `OpenAIDatasetGenerator` to generate these examples.\n",
     "\n",
-    "To avoid \"event loop already running in asyncio\", run the following code before using `OpenAIDatasetGenerator`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: nest-asyncio in /Users/zhaochen20/miniconda3/envs/prompt/lib/python3.11/site-packages (1.5.6)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install nest-asyncio"
+    "Note that there are a number of hyperparameters here. These are in general good defaults, but you might want to play with them. In particular, this is generating 5,000 examples which may be expensive, so you could choose to generate fewer."
    ]
   },
   {
@@ -392,22 +364,15 @@
    "outputs": [],
    "source": [
     "from prompt2model.dataset_generator import OpenAIDatasetGenerator, DatasetSplit\n",
-    "from prompt2model.utils.logging_utils import get_formatted_logger\n",
-    "import logging, nest_asyncio\n",
     "\n",
-    "nest_asyncio.apply()\n",
-    "\n",
-    "generator_logger = get_formatted_logger(\"DatasetGenerator\")\n",
-    "generator_logger.setLevel(logging.INFO)\n",
-    "\n",
-    "unlimited_dataset_generator = OpenAIDatasetGenerator(\n",
+    "dataset_generator = OpenAIDatasetGenerator(\n",
     "    initial_temperature=0.3,\n",
     "    max_temperature=1.4,\n",
     "    responses_per_request=3,\n",
     "    max_api_calls=10000,\n",
     "    requests_per_minute=80,\n",
     ")\n",
-    "generated_dataset = unlimited_dataset_generator.generate_dataset_split(\n",
+    "generated_dataset = dataset_generator.generate_dataset_split(\n",
     "    prompt_spec, 5000, split=DatasetSplit.TRAIN\n",
     ")\n",
     "generated_dataset.save_to_disk(\"generated_dataset\")"
@@ -576,7 +541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4
  },

--- a/notebook_demo.ipynb
+++ b/notebook_demo.ipynb
@@ -354,7 +354,7 @@
     "\n",
     "Next, we generate some examples for training the model. We can use `OpenAIDatasetGenerator` to generate these examples.\n",
     "\n",
-    "Note that there are a number of hyperparameters here. These are in general good defaults, but you might want to play with them. In particular, this is generating 5,000 examples which may be expensive, so you could choose to generate fewer."
+    "Note that there are a number of hyperparameters here. These are in general good defaults, but you might want to play with them. In particular, this generates 5,000 examples, which may be expensive (roughly $ 5), so you could choose to generate fewer."
    ]
   },
   {

--- a/prompt2model/dataset_generator/openai_gpt.py
+++ b/prompt2model/dataset_generator/openai_gpt.py
@@ -11,6 +11,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
+import nest_asyncio
 import openai
 from datasets import Dataset
 from tqdm import tqdm
@@ -26,6 +27,7 @@ from prompt2model.utils import (
     handle_openai_error,
 )
 
+nest_asyncio.apply()
 logger = get_formatted_logger("DatasetGenerator")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "termcolor==2.3.0",
     "psutil==5.9.5",
     "protobuf==3.20.0",
+    "nest-asyncio",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
# Description

This fixes wording up to the dataset generator, and moves the `nest_asyncio` out of the jupyter notebook into our library.

Note that I'm reverting the wording around the `.env` file, as the current wording may still encourage people to add the key to their jupyter notebook, which is not the best practice.

# Blocked by

- NA
