### PR TITLE
Wording fixes in prompt_examples.md

### DIFF
--- a/prompt_examples.md
+++ b/prompt_examples.md
@@ -39,7 +39,7 @@ about the format and scope of your examples.
 
 Here are some examples of good prompts:
 
-### Machine Reading Question Answer
+### Question Answering
 
 ```text
 """Your task is to generate an answer to a natural question. In this task, the input is a string that consists of both a question and a context passage. The context is a descriptive passage related to the question and contains the answer. And the question can range from Math, Cultural, Social, Geometry, Biology, History, Sports, Technology, Science, and so on.
@@ -113,7 +113,7 @@ output="N/A"
 """
 ```
 
-### Japanese2Python Generation
+### Japanese-to-Python Generation
 
 ```text
 """Pythonで1行のコードを生成し、StackOverflowの日本語の質問を解決してください。コメントや式は含めないでください。インポート文も不要です。


### PR DESCRIPTION
A few typo fixes in promp_examples.md.

* "Question Answer" should be "Question Answering"
* "Machine Reading" is a bit of an esoteric technical term, and can probably be removed.
* "Japanese-to-Python" is simpler English.
