### PR TITLE
Bump required Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 description = "A library for distilling models from prompts."
 readme = "README.md"
 repository = "https://github.com/neulab/prompt2model"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 classifiers = [
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
# Description

Bumps required Python version to 3.9 in pyproject.toml.

# References

- Fixes https://github.com/neulab/prompt2model/issues/311

# Blocked by

- NA
