### PR TITLE
Fixed error in type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,8 @@ repos:
         additional_dependencies:
           - flake8-future-import
         args:
-          - --select=FI
+          - --select=
+          - --ignore FI58
         entry: flake8
         files: '\.py$'
   - repo: https://github.com/pycqa/isort.git

--- a/prompt2model/dataset_processor/mock.py
+++ b/prompt2model/dataset_processor/mock.py
@@ -1,4 +1,5 @@
 """A mock dataset processor for testing purposes."""
+from __future__ import annotations
 
 import datasets
 

--- a/prompt2model/model_executor/mock.py
+++ b/prompt2model/model_executor/mock.py
@@ -1,4 +1,5 @@
 """A dummy class to generate model outputs (for testing purposes)."""
+from __future__ import annotations
 
 import datasets
 

--- a/prompt2model/model_retriever/base.py
+++ b/prompt2model/model_retriever/base.py
@@ -1,4 +1,5 @@
 """An interface for model selection."""
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 

--- a/prompt2model/model_retriever/mock.py
+++ b/prompt2model/model_retriever/mock.py
@@ -1,4 +1,5 @@
 """An interface for model selection."""
+from __future__ import annotations
 
 from prompt2model.model_retriever import ModelRetriever
 from prompt2model.prompt_parser import PromptSpec

--- a/prompt2model/param_selector/mock.py
+++ b/prompt2model/param_selector/mock.py
@@ -1,4 +1,5 @@
 """Mock model selector for testing purposes."""
+from __future__ import annotations
 
 from typing import Any
 

--- a/prompt2model/run_locally.py
+++ b/prompt2model/run_locally.py
@@ -1,4 +1,5 @@
 """A script to run the prompt2model pipeline locally."""
+from __future__ import annotations
 
 import argparse
 

--- a/prompt2model/utils/tevatron_utils/retrieve.py
+++ b/prompt2model/utils/tevatron_utils/retrieve.py
@@ -1,5 +1,6 @@
 """Tools for doing efficient similarity search via the Tevatron/faiss libraries."""
 from __future__ import annotations
+
 import pickle
 
 import numpy as np

--- a/prompt2model/utils/tevatron_utils/retrieve.py
+++ b/prompt2model/utils/tevatron_utils/retrieve.py
@@ -1,5 +1,5 @@
 """Tools for doing efficient similarity search via the Tevatron/faiss libraries."""
-
+from __future__ import annotations
 import pickle
 
 import numpy as np


### PR DESCRIPTION
# Description

I encountered this error while trying to import OpenAIInstructionParser, TaskType. Then, I solved that issue and further checked that the same issue is present in other files too, so solved them. also, pre-commit was throwing FI58 error while merging the new changes to added a parameter in pre-commit config to ignore the particular error.


TypeError                                 Traceback (most recent call last)
Cell In[1], line 1
----> 1 from prompt2model.prompt_parser import OpenAIInstructionParser, TaskType
      3 prompt_spec = OpenAIInstructionParser(task_type=TaskType.TEXT_GENERATION)
      4 prompt_spec.parse_from_prompt(prompt)

File ~/.pyenv/versions/3.8.17/lib/python3.8/site-packages/prompt2model/prompt_parser/__init__.py:3
      1 """Import PromptSpec classes."""
      2 from prompt2model.prompt_parser.base import PromptSpec, TaskType
----> 3 from prompt2model.prompt_parser.instr_parser import OpenAIInstructionParser
      4 from prompt2model.prompt_parser.mock import MockPromptSpec
      6 __all__ = (
      7     "PromptSpec",
      8     "TaskType",
      9     "MockPromptSpec",
     10     "OpenAIInstructionParser",
     11 )

File ~/.pyenv/versions/3.8.17/lib/python3.8/site-packages/prompt2model/prompt_parser/instr_parser.py:15
     10 from prompt2model.prompt_parser.base import PromptSpec, TaskType
     12 from prompt2model.prompt_parser.instr_parser_prompt import (  # isort: split
     13     construct_prompt_for_instruction_parsing,
     14 )
---> 15 from prompt2model.utils import (
     16     OPENAI_ERRORS,
     17     ChatGPTAgent,
     18     get_formatted_logger,
     19     handle_openai_error,
     20 )
     22 logger = get_formatted_logger("PromptParser")
     24 os.environ["TOKENIZERS_PARALLELISM"] = "false"

File ~/.pyenv/versions/3.8.17/lib/python3.8/site-packages/prompt2model/utils/__init__.py:10
      3 from prompt2model.utils.openai_tools import (
      4     OPENAI_ERRORS,
      5     ChatGPTAgent,
      6     count_tokens_from_string,
      7     handle_openai_error,
      8 )
      9 from prompt2model.utils.rng import seed_generator
---> 10 from prompt2model.utils.tevatron_utils import encode_text, retrieve_objects
     12 __all__ = (  # noqa: F401
     13     "ChatGPTAgent",
     14     "encode_text",
   (...)
     20     "get_formatted_logger",
     21 )

File ~/.pyenv/versions/3.8.17/lib/python3.8/site-packages/prompt2model/utils/tevatron_utils/__init__.py:3
      1 """Import Tevatron utility functions."""
      2 from prompt2model.utils.tevatron_utils.encode import encode_text
----> 3 from prompt2model.utils.tevatron_utils.retrieve import retrieve_objects
      5 __all__ = ("encode_text", "retrieve_objects")

File ~/.pyenv/versions/3.8.17/lib/python3.8/site-packages/prompt2model/utils/tevatron_utils/retrieve.py:11
      4 import numpy as np
      5 from tevatron.faiss_retriever import BaseFaissIPRetriever
      8 def retrieve_objects(
      9     query_vector: np.ndarray,
     10     encoded_datasets_path: str,
---> 11     document_names: list[str],
     12     depth: int,
     13 ) -> list[tuple[str, float]]:
     14     """Return a ranked list of object indices and their scores.
     15 
     16     Args:
   (...)
     22         Ranked list of object names and their inner product similarity to the query.
     23     """
     24     assert query_vector.shape[0] == 1, "Only a single query vector is expected."

TypeError: 'type' object is not subscriptable

# References

Below mentioned issue is solved by this PR

- https://github.com/neulab/prompt2model/issues/325
