### PR TITLE
Fix grammaticality of a single comment

### DIFF
--- a/prompt2model/dataset_generator/prompt_based.py
+++ b/prompt2model/dataset_generator/prompt_based.py
@@ -148,7 +148,7 @@ class PromptBasedDatasetGenerator(DatasetGenerator):
                 generated examples.
             generated_examples: A list of currently generated examples.
             context_cutoff: If the total length of the prompt in tokens exceeds this
-                value, repeat prompt generation process to generate a shorter one.
+                value, repeat the prompt generation process to generate a shorter one.
 
         Returns:
             The generated prompt string.


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

There's one comment with a missing article before a noun, and this PR fixes that grammar error.

# References

N/A

# Blocked by

N/A
