### PR TITLE
Add api_tools import to utils init file (to fix #346)

### DIFF
--- a/prompt2model/utils/__init__.py
+++ b/prompt2model/utils/__init__.py
@@ -1,4 +1,5 @@
 """Import utility functions."""
+import prompt2model.utils.api_tools as api_tools
 from prompt2model.utils.api_tools import (
     API_ERRORS,
     APIAgent,
@@ -10,6 +11,7 @@ from prompt2model.utils.rng import seed_generator
 from prompt2model.utils.tevatron_utils import encode_text, retrieve_objects
 
 __all__ = (  # noqa: F401
+    "api_tools",
     "APIAgent",
     "encode_text",
     "handle_api_error",


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

#344 makes the API-based model used in prompt2model configurable, but there's a bug in the notebook file where the default api agent (`api_tools.default_api_agent`) is set configurably, but this variable is not exposed in the current pip release.

This PR makes it such that this file can be accessed from the pip package.

# References

This PR fixes issue #346.

# Blocked by

N/A
