### PR TITLE
Configure dataset size in demo script and notebook (fixes #273)

### DIFF
--- a/prompt2model/utils/dataset_utils.py
+++ b/prompt2model/utils/dataset_utils.py
@@ -28,6 +28,6 @@ def get_dataset_size(dataset_name):
     size_dict = data.get("size", {})
     return (
         "NA"
-        if size_dict is {}
+        if size_dict == {}
         else "{:.2f}".format(size_dict["dataset"]["num_bytes_memory"] / 1024 / 1024)
     )

--- a/prompt2model_demo.ipynb
+++ b/prompt2model_demo.ipynb
@@ -166,9 +166,12 @@
    "source": [
     "## Retrieve Model\n",
     "\n",
-    "First, we retrieve a base model that we will train. We can use the `DescriptionModelRetriever` to do so.\n",
+    "First, we retrieve a base model that we will train. We can use the `DescriptionModelRetr
+iever` to do so. We can set `model_size_limit_bytes` to set the maximum size of a model (in by
+tes) to retrieve. In this block we use a maximum model size of 3GB by default.\n",
     "\n",
-    "`top_model_names` is a list of pretrained Hugging Face models. You can choose the first one by default."
+    "This class returns a list of pretrained Hugging Face models. You can choose the first on
+e by default."
    ]
   },
   {

--- a/prompt2model_demo.ipynb
+++ b/prompt2model_demo.ipynb
@@ -183,6 +183,7 @@
     "    model_descriptions_index_path=\"huggingface_data/huggingface_models/model_info/\",\n",
     "    use_bm25=True,\n",
     "    use_HyDE=True,\n",
+    "    model_size_limit_bytes=3e9,\n",
     ")\n",
     "top_model_names = retriever.retrieve(prompt_spec)\n",
     "pre_train_model_name = top_model_names[0]\n",

--- a/prompt2model_demo.py
+++ b/prompt2model_demo.py
@@ -98,8 +98,7 @@ def parse_model_size_limit(line: str, default_size=3e9) -> float:
     }
     unit_matched = False
     for unit, disambiguations in unit_disambiguations.items():
-        all_disambiguations = [unit] + disambiguations
-        for unit_name in all_disambiguations:
+        for unit_name in [unit] + disambiguations:
             if line.strip().endswith(unit_name):
                 unit_matched = True
                 break

--- a/prompt2model_demo.py
+++ b/prompt2model_demo.py
@@ -203,6 +203,7 @@ def main():
         )
         max_size_line = input()
         max_size = parse_model_size_limit(max_size_line)
+        line_print(f"Maximum model size set to {max_size} bytes.")
 
         line_print("Retrieving model...")
         prompt_spec = MockPromptSpec(

--- a/prompt2model_demo.py
+++ b/prompt2model_demo.py
@@ -78,6 +78,45 @@ def print_logo():
     line_print(centered_ascii_art)
 
 
+def parse_model_size_limit(line: str, default_size=3e9) -> float:
+    """Parse the user input for the maximum size of the model.
+
+    Args:
+        line: The user input.
+        default_size: The default size to use if the user does not specify a size.
+    """
+    if len(line.strip()) == 0:
+        return default_size
+    model_units = {"B": 1e0, "KB": 1e3, "MB": 1e6, "GB": 1e9, "TB": 1e12, "PB": 1e15}
+    unit_disambiguations = {
+        "B": ["b", "bytes"],
+        "KB": ["Kb", "kb", "kilobytes"],
+        "MB": ["Mb", "mb", "megabytes"],
+        "GB": ["Gb", "gb", "gigabytes"],
+        "TB": ["Tb", "tb", "terabytes"],
+        "PB": ["Pb", "pb", "petabytes"],
+    }
+    unit_matched = False
+    for unit, disambiguations in unit_disambiguations.items():
+        all_disambiguations = [unit] + disambiguations
+        for unit_name in all_disambiguations:
+            if line.strip().endswith(unit_name):
+                unit_matched = True
+                break
+        if unit_matched:
+            break
+    if unit_matched:
+        numerical_part = line.strip()[: -len(unit_name)].strip()
+    else:
+        numerical_part = line.strip()
+    if not str.isdecimal(numerical_part):
+        raise ValueError(
+            "Invalid input. Please enter a number (integer " + "or number with units)."
+        )
+    scale_factor = model_units[unit] if unit_matched else 1
+    return int(numerical_part) * scale_factor
+
+
 def main():
     """The main function running the whole system."""
     print_logo()
@@ -157,6 +196,14 @@ def main():
         and dataset_has_been_retrieved
         and not model_has_been_retrieved
     ):
+        line_print(
+            "Enter the maximum size of the model (by default, enter nothing "
+            + "and we will use 3GB as the limit). You can specify a unit (e.g. "
+            + "3GB, 300Mb). If no unit is given, we assume the size is given in bytes."
+        )
+        max_size_line = input()
+        max_size = parse_model_size_limit(max_size_line)
+
         line_print("Retrieving model...")
         prompt_spec = MockPromptSpec(
             TaskType.TEXT_GENERATION, status["instruction"], status["examples"]
@@ -165,6 +212,7 @@ def main():
             model_descriptions_index_path="huggingface_data/huggingface_models/model_info/",  # noqa E501
             use_bm25=True,
             use_HyDE=True,
+            model_size_limit_bytes=max_size,
         )
         top_model_name = retriever.retrieve(prompt_spec)
         line_print("Here are the models we retrieved.")


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

This PR makes it easy to set the maximum model size (in both the demo script and the demo notebook). This PR also fixes a one-line bug in the dataset retriever, for convenience.

Example of how to set the maximum model size in the demo script:
![Screenshot 2023-09-21 at 2 30 51 PM](https://github.com/neulab/prompt2model/assets/2577384/7881c637-e135-49d4-926a-e5ed24547c97)


# References

N/A

# Blocked by

N/A