### PR TITLE
Column Selection: Improvements

### DIFF
--- a/prompt2model/dataset_retriever/column_selection_prompt.py
+++ b/prompt2model/dataset_retriever/column_selection_prompt.py
@@ -7,14 +7,17 @@ import json
 METAPROMPT_BASE = """Your objective is to carefully analyze the task and the dataset mentioned, and decide whether the columns are relevant input, relevant output, irrelevant for the given task, or if it is ambiguous. There should be at most one output column. It is possible to have no relevant columns, in which case return the input and output column as empty lists.  Answer in a json format, with the following keys: input, output, irrelevant, ambiguous"""  # noqa: E501
 METAPROMPT_EXAMPLES = [
     (
-        """You are tasked with the following process. In this task, you will generate summaries for given texts. For this task, you will use the Scientific Papers dataset from HuggingFace. A sample data instance from this dataset is as follows.
+        """You are tasked with the following process. In this task, you will generate summaries for given texts. For this task, you will use the Scientific Papers dataset from HuggingFace. Dataset_description: Scientific papers datasets contains two sets of long and structured documents. The datasets are obtained from ArXiv and PubMed OpenAccess repositories.
+        A sample data instance from this dataset is as follows.
         {
-        "abstract": "\" we have studied the leptonic decay @xmath0 , via the decay channel @xmath1 , using a sample of tagged @xmath2 decays collected...",
-        "article": "\"the leptonic decays of a charged pseudoscalar meson @xmath7 are processes of the type @xmath8 , where @xmath9 , @xmath10 , or @...",
-        "section_names": "[sec:introduction]introduction\n[sec:detector]data and the cleo- detector\n[sec:analysys]analysis method\n[sec:conclusion]summary"
-        }. This dataset has the following columns: [abstract, article, section_names].
+            "abstract": "\" we have studied the leptonic decay @xmath0 , via the decay channel @xmath1 , using a sample of tagged @xmath2 decays collected...",
+            "article": "\"the leptonic decays of a charged pseudoscalar meson @xmath7 are processes of the type @xmath8 , where @xmath9 , @xmath10 , or @...",
+            "section_names": "[sec:introduction]introduction\n[sec:detector]data and the cleo- detector\n[sec:analysys]analysis method\n[sec:conclusion]summary"
+        }
+        This dataset has the following columns: [abstract, article, section_names].
         """,  # noqa: E501
-        """ {
+        """
+        {
             "input": ["article"],
             "output": ["abstract"],
             "irrelevant": ["section_names"],
@@ -23,34 +26,64 @@ METAPROMPT_EXAMPLES = [
     ),
     (
         """
-        You are tasked with the following process. In this task, you will detect whether some given text uses hateful speech or not. For this task you will use the hate_speech_offensive dataset from HuggingFace. A sample data instance from this is as follows: {
-"count": 3,
- "hate_speech_count": 0,
- "offensive_language_count": 0,
- "neither_count": 3,
- "label": 2,  # "neither"
- "tweet": "!!! RT @mayasolovely: As a woman you shouldn't complain about cleaning up your house. &amp; as a man you should always take the trash out...")
-}. This dataset has the following columns: [count, hate_speech_count, offensive_language_count, neither_count, class, tweet]""",  # noqa: E501
-        """{
-        "input": ["tweet"],
-        "output": ["label"],
-        "irrelevant": [],
-        "ambiguous": ["hate_speech_count", "offensive_language_count", "neither_count", "count"]
+        You are tasked with the following process. In this task, you will detect whether some given text uses hateful speech or not. For this task you will use the hate_speech_offensive dataset from HuggingFace. Dataset_description: An annotated dataset for hate speech and offensive language detection on tweets.
+        A sample data instance from this is as follows:
+        {
+            "count": 3,
+            "hate_speech_count": 0,
+            "offensive_language_count": 0,
+            "neither_count": 3,
+            "label": 2,  # "neither"
+            "tweet": "!!! RT @mayasolovely: As a woman you shouldn't complain about cleaning up your house. &amp; as a man you should always take the trash out...")
+        }.
+        This dataset has the following columns: [count, hate_speech_count, offensive_language_count, neither_count, class, tweet]""",  # noqa: E501
+        """
+        {
+            "input": ["tweet"],
+            "output": ["label"],
+            "irrelevant": [],
+            "ambiguous": ["hate_speech_count", "offensive_language_count", "neither_count", "count"]
         }""",  # noqa: E501
     ),
     (
-        """You are tasked with the following process. Your job is to be able to translate between languages. For this task, you will use the Opus100 dataset from HuggingFace. A sample data instance from this is as follows:  {"translation":{ "ca": "El department de bombers té el seu propi equip d'investigació.", "en": "Well, the fire department has its own investigative unit." }}. This dataset has the following columns: [translation]. """,  # noqa: E501
-        """{
-        "input": [],
-        "output": [],
-        "irrelevant": []
-        "ambiguous": ["translation"]
+        """You are tasked with the following process. Your job is to be able to translate between languages. For this task, you will use a custom dataset. Dataset_description: This dataset is meant to translate between languages.
+        A sample data instance from this is as follows:
+        {
+            "translation": ["ca: "El department de bombers té el seu propi equip d'investigació.", "en": "Well, the fire department has its own investigative unit."]
+        }
+        This dataset has the following columns: [translation]. """,  # noqa: E501
+        """
+        {
+            "input": [],
+            "output": [],
+            "irrelevant": []
+            "ambiguous": ["translation"]
         }""",
+    ),
+    (
+        """You are tasked with the following process. Your job is to be able to summarize a given text. For this task, you will use the math_qa dataset from HuggingFace. Dataset_description: Our dataset is gathered by using a new representation language to annotate over the AQuA-RAT dataset with fully-specified operational programs.
+        A sample data instance from this is as follows:
+        {
+            "Problem": "a multiple choice test consists of 4 questions , and each question has 5 answer choices . in how many r ways can the test be completed if every question is unanswered ?",
+            "Rationale": "\"5 choices for each of the 4 questions , thus total r of 5 * 5 * 5 * 5 = 5 ^ 4 = 625 ways to answer all of them . answer : c .\"",
+            "annotated_formula": "power(5, 4)",
+            "category": "general",
+            "correct": "c",
+            "linear_formula": "power(n1,n0)|",
+            "options": "a ) 24 , b ) 120 , c ) 625 , d ) 720 , e ) 1024"
+        }
+        This dataset has the following columns: [problem, rationale, options, correct, annotated_formula]. """,  # noqa: E501
+        """
+        {
+            "input": [],
+            "output": [],
+            "irrelevant": ["problem", "rationale", "options", "correct", "annotated_formula"],
+            "ambiguous": []
+        }""",  # noqa: E501
     ),
 ]
 
-INPUT_PROMPT_TEMPLATE = """You are tasked with the following process. {instruction} For this task, you will use the {dataset_name} dataset from HuggingFace.  A sample data instance from this is as follows. {sample_row}.
-This dataset has the following columns: [{dataset_columns} ]."""  # noqa: E501
+INPUT_PROMPT_TEMPLATE = """You are tasked with the following process. {instruction} For this task, you will use the {dataset_name} dataset from HuggingFace. Dataset Description: {dataset_description} \nA sample data instance from this is as follows. {sample_row}.\nThis dataset has the following columns: [{dataset_columns} ]."""  # noqa: E501
 SINGLE_DEMONSTRATION_TEMPLATE = (
     'Task: """\n{prompt}\n"""\n\nRequired Columns :\n{columns}'
 )
@@ -61,17 +94,25 @@ def truncate_row(example_row: dict, max_length=50) -> str:
     """Truncate the row before displaying if it is too long."""
     truncated_row = {}
     for key in example_row.keys():
-        truncated_row[key] = json.dumps(example_row[key])[:max_length] + "..."
+        curr_row = json.dumps(example_row[key])
+        truncated_row[key] = (
+            curr_row if len(curr_row) <= max_length else curr_row[:max_length] + "..."
+        )
     return json.dumps(truncated_row)
 
 
 def build_input(
-    instruction: str, dataset_name: str, dataset_columns: str, sample_row: dict
+    instruction: str,
+    dataset_name: str,
+    dataset_description: str,
+    dataset_columns: str,
+    sample_row: dict,
 ) -> str:
     """Template function to build input based on arguments."""
     input_prompt = INPUT_PROMPT_TEMPLATE.format(
         instruction=instruction,
         dataset_name=dataset_name,
+        dataset_description=dataset_description,
         dataset_columns=dataset_columns,
         sample_row=truncate_row(sample_row),
     )
@@ -82,7 +123,11 @@ def build_input(
 
 
 def construct_prompt_for_column_selection(
-    instruction: str, dataset_name: str, dataset_columns: str, sample_row: dict
+    instruction: str,
+    dataset_name: str,
+    dataset_description: str,
+    dataset_columns: str,
+    sample_row: dict,
 ) -> str:
     """Generate prompt for column selection."""
     prompt_sections = [METAPROMPT_BASE]
@@ -91,7 +136,9 @@ def construct_prompt_for_column_selection(
             SINGLE_DEMONSTRATION_TEMPLATE.format(prompt=prompt, columns=columns)
         )
     all_prompts = "\n\n------\n\n".join(prompt_sections) + "\n\n------\n\n"
-    input_prompt = build_input(instruction, dataset_name, dataset_columns, sample_row)
+    input_prompt = build_input(
+        instruction, dataset_name, dataset_description, dataset_columns, sample_row
+    )
     all_prompts += ENDING_LINE + input_prompt
 
     return all_prompts

--- a/prompt2model/dataset_retriever/column_selection_prompt.py
+++ b/prompt2model/dataset_retriever/column_selection_prompt.py
@@ -23,14 +23,20 @@ METAPROMPT_EXAMPLES = [
     ),
     (
         """
-        You are tasked with the following process. In this task, the input is a string that consists of both a question and a context passage. The context is a descriptive passage related to the question and contains the answer. And the question can range from Math, Cultural, Social, Geometry, Biology, History, Sports, Technology, Science, and so on.  For this task, you will use the Children's Book Test dataset from HuggingFace. A sample data instance from this dataset is as follows: {'answer': 'said', 'options': ['christening', 'existed', 'hear', 'knows', 'read', 'remarked', 'said', 'sitting', 'talking', 'wearing'], 'question': "`` They are very kind old ladies in their way , '' XXXXX the king ; `` and were nice to me when I was a boy . ''", 'sentences': ['This vexed the king even more than the queen , who was very clever and learned , and who had hated dolls when she was a child .', 'However , she , too in spite of all the books she read and all the pictures she painted , would have been glad enough to be the mother of a little prince .', 'The king was anxious to consult the fairies , but the queen would not hear of such a thing .', 'She did not believe in fairies : she said that they had never existed ; and that she maintained , though The History of the Royal Family was full of chapters about nothing else .', 'Well , at long and at last they had a little boy , who was generally regarded as the finest baby that had ever been seen .', 'Even her majesty herself remarked that , though she could never believe all the courtiers told her , yet he certainly was a fine child -- a very fine child .', 'Now , the time drew near for the christening party , and the king and queen were sitting at breakfast in their summer parlour talking over it .', 'It was a splendid room , hung with portraits of the royal ancestors .', 'There was Cinderella , the grandmother of the reigning monarch , with her little foot in her glass slipper thrust out before her .'"]}
-        This dataset has the following columns: [sentences, questions, answers, options]""",  # noqa: E501
+        You are tasked with the following process. In this task, you will detect whether some given text uses hateful speech or not. For this task you will use the hate_speech_offensive dataset from HuggingFace. A sample data instance from this is as follows: {
+"count": 3,
+ "hate_speech_count": 0,
+ "offensive_language_count": 0,
+ "neither_count": 3,
+ "label": 2,  # "neither"
+ "tweet": "!!! RT @mayasolovely: As a woman you shouldn't complain about cleaning up your house. &amp; as a man you should always take the trash out...")
+}. This dataset has the following columns: [count, hate_speech_count, offensive_language_count, neither_count, class, tweet]""",  # noqa: E501
         """{
-        "input": ["context", "question"],
-        "output": ["answer"],
+        "input": ["tweet"],
+        "output": ["label"],
         "irrelevant": [],
-        "ambiguous": ["options"]
-        }""",
+        "ambiguous": ["hate_speech_count", "offensive_language_count", "neither_count", "count"]
+        }""",  # noqa: E501
     ),
     (
         """You are tasked with the following process. Your job is to be able to translate between languages. For this task, you will use the Opus100 dataset from HuggingFace. A sample data instance from this is as follows:  {"translation":{ "ca": "El department de bombers té el seu propi equip d'investigació.", "en": "Well, the fire department has its own investigative unit." }}. This dataset has the following columns: [translation]. """,  # noqa: E501

--- a/prompt2model/dataset_retriever/column_selection_prompt.py
+++ b/prompt2model/dataset_retriever/column_selection_prompt.py
@@ -96,7 +96,9 @@ def truncate_row(example_row: dict, max_length=50) -> str:
     for key in example_row.keys():
         curr_row = json.dumps(example_row[key])
         truncated_row[key] = (
-            curr_row if len(curr_row) <= max_length else curr_row[:max_length] + "..."
+            curr_row
+            if len(curr_row) <= max_length - 3
+            else curr_row[:max_length] + "..."
         )
     return json.dumps(truncated_row)
 

--- a/prompt2model/dataset_retriever/description_dataset_retriever.py
+++ b/prompt2model/dataset_retriever/description_dataset_retriever.py
@@ -252,10 +252,15 @@ class DescriptionDatasetRetriever(DatasetRetriever):
 
         if "train" not in dataset:
             raise ValueError("The dataset must contain a `train` split.")
-
-        columns_mapping = {
-            col: col.replace(".", "_") for col in dataset["train"].column_names
-        }  # convert flattened columns like answer.text -> answer_text
+        columns_mapping: dict[str, str] = {}
+        counter: dict[str, int] = {}
+        # convert flattened columns like answer.text -> answer_text
+        for col in dataset["train"].column_names:
+            new_col = col.replace(".", "_")
+            if new_col in columns_mapping.values():
+                counter[new_col] = counter.get(new_col, 0) + 1
+                new_col = f"{new_col}_{counter[new_col]}"
+            columns_mapping[col] = new_col
         dataset = dataset.rename_columns(columns_mapping)
 
         train_columns = dataset["train"].column_names

--- a/prompt2model/dataset_retriever/description_dataset_retriever.py
+++ b/prompt2model/dataset_retriever/description_dataset_retriever.py
@@ -167,11 +167,19 @@ class DescriptionDatasetRetriever(DatasetRetriever):
 
     @staticmethod
     def automatic_column_selection(
-        instruction: str, dataset_name: str, dataset_columns: str, example_rows: dict
+        instruction: str,
+        dataset_name: str,
+        dataset_description: str,
+        dataset_columns: str,
+        example_rows: dict,
     ) -> tuple[list[str], str]:
         """Find appropriate input and output columns for a given dataset and tasks."""
         prompt = construct_prompt_for_column_selection(
-            instruction, dataset_name, dataset_columns, example_rows
+            instruction,
+            dataset_name,
+            dataset_description,
+            dataset_columns,
+            example_rows,
         )
         required_keys = ["input", "output"]
         optional_keys = ["ambiguous", "irrelevant"]
@@ -240,11 +248,19 @@ class DescriptionDatasetRetriever(DatasetRetriever):
                     )
             self._print_divider()
 
-        dataset = datasets.load_dataset(dataset_name, chosen_config)
+        dataset = datasets.load_dataset(dataset_name, chosen_config).flatten()
+
         if "train" not in dataset:
             raise ValueError("The dataset must contain a `train` split.")
+
+        columns_mapping = {
+            col: col.replace(".", "_") for col in dataset["train"].column_names
+        }  # convert flattened columns like answer.text -> answer_text
+        dataset = dataset.rename_columns(columns_mapping)
+
         train_columns = dataset["train"].column_names
         train_columns_formatted = ", ".join(train_columns)
+        dataset_description = dataset["train"].info.description
 
         if len(dataset["train"]) == 0:
             raise ValueError("train split is empty.")
@@ -257,6 +273,7 @@ class DescriptionDatasetRetriever(DatasetRetriever):
             input_columns, output_column = self.automatic_column_selection(
                 prompt_spec.instruction,
                 dataset_name,
+                dataset_description,
                 train_columns_formatted,
                 dataset["train"][0],
             )


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

- Tried to add information about columns from huggingface, but I couldn't find anything super relevant. So I decided to just add the dataset description instead. Made the appropriate changes in the base prompt as well.
- Updated the prompt for column selection by (1) adding an example where there is a mismatch between the task and dataset chosen, so there are no relevant columns (eg using a machine translation dataset for a summarization task), and (2) swapped an old example for another one
- Fixed bug in truncate_row -- only add the "..." if len(row) > max_length
- Added support for datasets like opus100 (which have nested columns), so that these datasets can be used and we don't try to generate a dataset -- the solution was pretty straightforward, using flatten() function of huggingface + some trivial column preprocessing
