### PR TITLE
Loosen version requirement for protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyfiglet",
     "termcolor",
     "psutil",
-    "protobuf==3.20.0",
+    "protobuf",
     "nest-asyncio",
     "litellm"
 ]


### PR DESCRIPTION
# Description

The protobuf version required by prompt2model was specified as 3.20.0. However this is restrictive and may cause dependency issues when used in conjunction with other libraries (eg. the latest tensorflow version requires protobuf >= 3.20.3). This was originally pinned due to certain HF models requiring a specific protobuf but that issue has since been resolved by HF (see references).

I also tested a fresh install of p2m without the protobuf pinned version and both the demo notebook and python script work as expected.

# References

- #309 
- https://github.com/huggingface/transformers/pull/24599