### PR TITLE
Specify library versions for openai and litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "gradio",
     "torch",
     "pytest",
-    "openai",
+    "openai==0.27.10",
     "sentencepiece",
     "bert_score",
     "sacrebleu",
@@ -45,7 +45,7 @@ dependencies = [
     "psutil",
     "protobuf",
     "nest-asyncio",
-    "litellm"
+    "litellm==0.1.583"
 ]
 
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "datasets",
     "pandas",
     "fastapi",
-    "gradio",
+    "gradio==3.38.0",
     "torch",
     "pytest",
     "openai==0.27.10",


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Our demo script is breaking due to a change in the latest OpenAI and LiteLLM APIs, as shown by issue #377. This script pins the openai and litellm versions to versions that we have tested - we will update the code to work with the latest versions of these libraries in a future PR.

# References

#377

# Blocked by

N/A
