### PR TITLE
Use temporary file for tarball instead of tmp directory (fixes #387)

### DIFF
--- a/prompt2model/model_retriever/description_based_retriever.py
+++ b/prompt2model/model_retriever/description_based_retriever.py
@@ -131,11 +131,10 @@ class DescriptionModelRetriever(ModelRetriever):
         """
         if not os.path.isdir(self.model_descriptions_index_path):
             # If the model descriptions directory is not populated, then populate it.
-            urllib.request.urlretrieve(
-                "http://phontron.com/data/prompt2model/model_info.tgz",
-                "/tmp/model_info.tgz",
+            temporary_file, _ = urllib.request.urlretrieve(
+                "http://phontron.com/data/prompt2model/model_info.tgz"
             )
-            tar = tarfile.open("/tmp/model_info.tgz")
+            tar = tarfile.open(temporary_file)
             os.makedirs(self.model_descriptions_index_path)
             tar.extractall(path=self.model_descriptions_index_path)
 


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Description

Our current code relies on the `/tmp/` directory, which is not guaranteed to exist on non-Linux operating systems, such as Windows. This PR uses the temporary file functionality in `urllib.request.urlretrieve` to avoid explicitly assuming anything about the local file structure.

# References

N/A

# Blocked by

N/A
