### PR TITLE
Migrate to the latest openAI version

### DIFF
--- a/prompt2model/utils/api_tools.py
+++ b/prompt2model/utils/api_tools.py
@@ -96,12 +96,11 @@ class APIAgent:
             An OpenAI-like response object if there were no errors in generation.
             In case of API-specific error, Exception object is captured and returned.
         """
-        # num_prompt_tokens = count_tokens_from_string(prompt)
-        # if self.max_tokens:
-        #     max_tokens = self.max_tokens - num_prompt_tokens - token_buffer
-        # else:
-        #     max_tokens = 3 * num_prompt_tokens
-        max_tokens = self.max_tokens
+        num_prompt_tokens = count_tokens_from_string(prompt)
+        if self.max_tokens:
+            max_tokens = self.max_tokens - num_prompt_tokens - token_buffer
+        else:
+            max_tokens = 3 * num_prompt_tokens
 
         response = completion(  # completion gets the key from os.getenv
             model=self.model_name,

--- a/prompt2model/utils/api_tools.py
+++ b/prompt2model/utils/api_tools.py
@@ -19,7 +19,7 @@ from tqdm.asyncio import tqdm_asyncio
 # so openai errors are valid even when using other services.
 API_ERRORS = (
     openai.APIError,
-    openai.Timeout,
+    openai.APITimeoutError,
     openai.RateLimitError,
     openai.BadRequestError,
     openai.APIStatusError,
@@ -31,7 +31,7 @@ ERROR_ERRORS_TO_MESSAGES = {
     openai.BadRequestError: "API Invalid Request: Prompt was filtered",
     openai.RateLimitError: "API rate limit exceeded. Sleeping for 10 seconds.",
     openai.APIConnectionError: "Error Communicating with API",
-    openai.Timeout: "API Timeout Error: API Timeout",
+    openai.APITimeoutError: "API Timeout Error: API Timeout",
     openai.APIStatusError: "API service unavailable error: {e}",
     openai.APIError: "API error: {e}",
 }
@@ -230,7 +230,7 @@ def handle_api_error(e) -> None:
         raise e
     if isinstance(
         e,
-        (openai.APIError, openai.Timeout, openai.RateLimitError),
+        (openai.APIError, openai.APITimeoutError, openai.RateLimitError),
     ):
         # For these errors, OpenAI recommends waiting before retrying.
         time.sleep(1)

--- a/prompt2model/utils/api_tools.py
+++ b/prompt2model/utils/api_tools.py
@@ -19,22 +19,22 @@ from tqdm.asyncio import tqdm_asyncio
 # Note that litellm converts all API errors into openai errors,
 # so openai errors are valid even when using other services.
 API_ERRORS = (
-    openai.error.APIError,
-    openai.error.Timeout,
-    openai.error.RateLimitError,
-    openai.error.ServiceUnavailableError,
-    openai.error.InvalidRequestError,
+    openai.APIError,
+    openai.Timeout,
+    openai.RateLimitError,
+    openai.ServiceUnavailableError,
+    openai.InvalidRequestError,
     json.decoder.JSONDecodeError,
     AssertionError,
 )
 
 ERROR_ERRORS_TO_MESSAGES = {
-    openai.error.InvalidRequestError: "API Invalid Request: Prompt was filtered",
-    openai.error.RateLimitError: "API rate limit exceeded. Sleeping for 10 seconds.",
-    openai.error.APIConnectionError: "Error Communicating with API",
-    openai.error.Timeout: "API Timeout Error: API Timeout",
-    openai.error.ServiceUnavailableError: "API service unavailable error: {e}",
-    openai.error.APIError: "API error: {e}",
+    openai.InvalidRequestError: "API Invalid Request: Prompt was filtered",
+    openai.RateLimitError: "API rate limit exceeded. Sleeping for 10 seconds.",
+    openai.APIConnectionError: "Error Communicating with API",
+    openai.Timeout: "API Timeout Error: API Timeout",
+    openai.ServiceUnavailableError: "API service unavailable error: {e}",
+    openai.APIError: "API error: {e}",
 }
 
 
@@ -170,14 +170,14 @@ class APIAgent:
                         if isinstance(
                             e,
                             (
-                                openai.error.ServiceUnavailableError,
-                                openai.error.APIError,
+                                openai.ServiceUnavailableError,
+                                openai.APIError,
                             ),
                         ):
                             logging.warning(
                                 ERROR_ERRORS_TO_MESSAGES[type(e)].format(e=e)
                             )
-                        elif isinstance(e, openai.error.InvalidRequestError):
+                        elif isinstance(e, openai.InvalidRequestError):
                             logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
                             return {
                                 "choices": [
@@ -231,7 +231,7 @@ def handle_api_error(e) -> None:
         raise e
     if isinstance(
         e,
-        (openai.error.APIError, openai.error.Timeout, openai.error.RateLimitError),
+        (openai.APIError, openai.Timeout, openai.RateLimitError),
     ):
         # For these errors, OpenAI recommends waiting before retrying.
         time.sleep(1)

--- a/prompt2model/utils/api_tools.py
+++ b/prompt2model/utils/api_tools.py
@@ -169,14 +169,14 @@ class APIAgent:
                         if isinstance(
                             e,
                             (
-                                openai.ServiceUnavailableError,
+                                openai.APIStatusError,
                                 openai.APIError,
                             ),
                         ):
                             logging.warning(
                                 ERROR_ERRORS_TO_MESSAGES[type(e)].format(e=e)
                             )
-                        elif isinstance(e, openai.InvalidRequestError):
+                        elif isinstance(e, openai.BadRequestError):
                             logging.warning(ERROR_ERRORS_TO_MESSAGES[type(e)])
                             return {
                                 "choices": [

--- a/prompt2model/utils/api_tools.py
+++ b/prompt2model/utils/api_tools.py
@@ -10,7 +10,6 @@ import time
 import aiolimiter
 import litellm.utils
 import openai
-import openai.error
 import tiktoken
 from aiohttp import ClientSession
 from litellm import acompletion, completion
@@ -22,18 +21,18 @@ API_ERRORS = (
     openai.APIError,
     openai.Timeout,
     openai.RateLimitError,
-    openai.ServiceUnavailableError,
-    openai.InvalidRequestError,
+    openai.BadRequestError,
+    openai.APIStatusError,
     json.decoder.JSONDecodeError,
     AssertionError,
 )
 
 ERROR_ERRORS_TO_MESSAGES = {
-    openai.InvalidRequestError: "API Invalid Request: Prompt was filtered",
+    openai.BadRequestError: "API Invalid Request: Prompt was filtered",
     openai.RateLimitError: "API rate limit exceeded. Sleeping for 10 seconds.",
     openai.APIConnectionError: "Error Communicating with API",
     openai.Timeout: "API Timeout Error: API Timeout",
-    openai.ServiceUnavailableError: "API service unavailable error: {e}",
+    openai.APIStatusError: "API service unavailable error: {e}",
     openai.APIError: "API error: {e}",
 }
 
@@ -97,11 +96,12 @@ class APIAgent:
             An OpenAI-like response object if there were no errors in generation.
             In case of API-specific error, Exception object is captured and returned.
         """
-        num_prompt_tokens = count_tokens_from_string(prompt)
-        if self.max_tokens:
-            max_tokens = self.max_tokens - num_prompt_tokens - token_buffer
-        else:
-            max_tokens = 3 * num_prompt_tokens
+        # num_prompt_tokens = count_tokens_from_string(prompt)
+        # if self.max_tokens:
+        #     max_tokens = self.max_tokens - num_prompt_tokens - token_buffer
+        # else:
+        #     max_tokens = 3 * num_prompt_tokens
+        max_tokens = self.max_tokens
 
         response = completion(  # completion gets the key from os.getenv
             model=self.model_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "gradio==3.38.0",
     "torch",
     "pytest",
-    "openai==0.27.10",
+    "openai",
     "sentencepiece",
     "bert_score",
     "sacrebleu",
@@ -45,7 +45,7 @@ dependencies = [
     "psutil",
     "protobuf",
     "nest-asyncio",
-    "litellm==0.1.583",
+    "litellm",
     "peft"
 ]
 

--- a/tests/prompt_parser_test.py
+++ b/tests/prompt_parser_test.py
@@ -136,7 +136,7 @@ def test_instruction_parser_with_invalid_json(mocked_parsing_method):
 @patch("time.sleep")
 @patch(
     "prompt2model.utils.APIAgent.generate_one_completion",
-    side_effect=openai.Timeout("timeout"),
+    side_effect=openai.APITimeoutError("timeout"),
 )
 def test_instruction_parser_with_timeout(mocked_parsing_method, mocked_sleep_method):
     """Verify that we wait and retry (a set number of times) if the API times out.
@@ -165,7 +165,7 @@ def test_instruction_parser_with_timeout(mocked_parsing_method, mocked_sleep_met
     assert isinstance(exc_info.value, RuntimeError)
     # Check if the original exception (e) is present as the cause
     original_exception = exc_info.value.__cause__
-    assert isinstance(original_exception, openai.Timeout)
+    assert isinstance(original_exception, openai.APITimeoutError)
     gc.collect()
 
 

--- a/tests/prompt_parser_test.py
+++ b/tests/prompt_parser_test.py
@@ -136,7 +136,7 @@ def test_instruction_parser_with_invalid_json(mocked_parsing_method):
 @patch("time.sleep")
 @patch(
     "prompt2model.utils.APIAgent.generate_one_completion",
-    side_effect=openai.error.Timeout("timeout"),
+    side_effect=openai.Timeout("timeout"),
 )
 def test_instruction_parser_with_timeout(mocked_parsing_method, mocked_sleep_method):
     """Verify that we wait and retry (a set number of times) if the API times out.
@@ -165,7 +165,7 @@ def test_instruction_parser_with_timeout(mocked_parsing_method, mocked_sleep_met
     assert isinstance(exc_info.value, RuntimeError)
     # Check if the original exception (e) is present as the cause
     original_exception = exc_info.value.__cause__
-    assert isinstance(original_exception, openai.error.Timeout)
+    assert isinstance(original_exception, openai.Timeout)
     gc.collect()
 
 


### PR DESCRIPTION
# Description

- ran the openai migrate script
- made migrations as per litellm breaking changes in new version
- tested the single generate function

This is high priority since the old versions of openai and litellm mean that users cannot use latest models like gpt-4-turbo since litellm is not able to map model name in such cases. Additionally, having a really old pinned version for both libraries will lead to further issues in the future.

# References

- #394 